### PR TITLE
fix tailwind lsp integration

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zed_templ"
-version = "0.0.2"
+version = "0.0.3"
 edition = "2021"
 publish = false
 license = "MIT"
@@ -10,4 +10,4 @@ path = "src/templ.rs"
 crate-type = ["cdylib"]
 
 [dependencies]
-zed_extension_api = "0.0.4"
+zed_extension_api = "0.0.6"

--- a/extension.toml
+++ b/extension.toml
@@ -10,6 +10,9 @@ repository = "https://github.com/makifdb/zed-templ"
 name = "Templ Language Server"
 language = "Templ"
 
+[language_servers.templ.language_ids]
+"Templ" = "templ"
+
 [grammars.templ]
 repository = "https://github.com/vrischmann/tree-sitter-templ"
 commit = "71978ef587a9e4456333d62a5929949669af66fc"

--- a/extension.toml
+++ b/extension.toml
@@ -1,6 +1,6 @@
 id = "templ"
 name = "Templ"
-version = "0.0.2"
+version = "0.0.3"
 schema_version = 1
 authors = ["Mehmet Akif Duba <mail@makifdb.com>"]
 description = "Templ language support for Zed"

--- a/languages/templ/config.toml
+++ b/languages/templ/config.toml
@@ -23,6 +23,7 @@ scope_opt_in_language_servers = [
 ]
 
 [overrides.string]
+word_characters = ["-"]
 opt_into_language_servers = [
     "tailwindcss-language-server",
     "vscode-html-language-server",

--- a/languages/templ/config.toml
+++ b/languages/templ/config.toml
@@ -7,6 +7,23 @@ brackets = [
     { start = "(", end = ")", close = true, newline = false },
     { start = "[", end = "]", close = true, newline = false },
     { start = "<", end = ">", close = true, newline = false },
-    { start = "'", end = "'", close = true, newline = false, not_in = ["comment", "string"] },
-    { start = "/*", end = " */", close = true, newline = false, not_in = ["comment", "string"] },
+    { start = "'", end = "'", close = true, newline = false, not_in = [
+        "comment",
+        "string",
+    ] },
+    { start = "/*", end = " */", close = true, newline = false, not_in = [
+        "comment",
+        "string",
+    ] },
+]
+scope_opt_in_language_servers = [
+    "tailwindcss-language-server",
+    "vscode-html-language-server",
+    "emmet-language-server",
+]
+
+[overrides.string]
+opt_into_language_servers = [
+    "tailwindcss-language-server",
+    "vscode-html-language-server",
 ]

--- a/languages/templ/overrides_go.scm
+++ b/languages/templ/overrides_go.scm
@@ -3,4 +3,6 @@
   (interpreted_string_literal)
   (raw_string_literal)
   (rune_literal)
+  (attribute_value)
+  (quoted_attribute_value)
 ] @string


### PR DESCRIPTION
The lack of tailwind integration was driving me crazy! This PR adds intellisense for tailwind classes when using Templ. Note that you will need the following Zed settings for the tailwind language server:

```json
"lsp": {
  "tailwindcss-language-server": {
    "settings": {
      "includeLanguages": {
        "templ": "HTML"
      }
    }
  }
},
```

This may help with #3 and I included the emmet language server as an opt-in although I have not tested that.