### PR TITLE
feat: add rawgo and vim mode support. Update tree-sitter-templ and go queries to latest

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zed_templ"
-version = "0.0.4"
+version = "0.0.5"
 edition = "2021"
 publish = false
 license = "MIT"

--- a/extension.toml
+++ b/extension.toml
@@ -1,6 +1,6 @@
 id = "templ"
 name = "Templ"
-version = "0.0.4"
+version = "0.0.5"
 schema_version = 1
 authors = ["Mehmet Akif Duba <mail@makifdb.com>"]
 description = "Templ language support for Zed"
@@ -15,4 +15,4 @@ language = "Templ"
 
 [grammars.templ]
 repository = "https://github.com/vrischmann/tree-sitter-templ"
-commit = "71978ef587a9e4456333d62a5929949669af66fc"
+commit = "9269b5a65e79be8fb6b6669935823263343b7ba0"

--- a/grammars/templ.toml
+++ b/grammars/templ.toml
@@ -1,2 +1,2 @@
 repository = "https://github.com/vrischmann/tree-sitter-templ"
-commit = "592faa3186ef857c92e4bd1c31d73c07a4a334db"
+commit = "9269b5a65e79be8fb6b6669935823263343b7ba0"

--- a/languages/templ/brackets.scm
+++ b/languages/templ/brackets.scm
@@ -1,0 +1,4 @@
+("<" @open "/>" @close)
+("</" @open ">" @close)
+("<" @open ">" @close)
+("{{" @open "}}" @close)

--- a/languages/templ/brackets_go.scm
+++ b/languages/templ/brackets_go.scm
@@ -1,3 +1,5 @@
+; From https://github.com/zed-industries/zed/blob/0f584cb353afe0483d8a044619b7dabcfcd10e40/crates/languages/src/go/brackets.scm
+
 ("(" @open ")" @close)
 ("[" @open "]" @close)
 ("{" @open "}" @close)

--- a/languages/templ/config.toml
+++ b/languages/templ/config.toml
@@ -1,13 +1,22 @@
 name = "Templ"
 grammar = "templ"
 path_suffixes = ["templ"]
-autoclose_before = "}"
+line_comments = ["// "]
+autoclose_before = ";:.,=}])>"
 brackets = [
     { start = "{", end = "}", close = true, newline = true },
     { start = "(", end = ")", close = true, newline = false },
     { start = "[", end = "]", close = true, newline = false },
     { start = "<", end = ">", close = true, newline = false },
+    { start = "\"", end = "\"", close = true, newline = false, not_in = [
+        "comment",
+        "string",
+    ] },
     { start = "'", end = "'", close = true, newline = false, not_in = [
+        "comment",
+        "string",
+    ] },
+    { start = "`", end = "`", close = true, newline = false, not_in = [
         "comment",
         "string",
     ] },
@@ -16,6 +25,8 @@ brackets = [
         "string",
     ] },
 ]
+tab_size = 4
+hard_tabs = true
 scope_opt_in_language_servers = [
     "tailwindcss-language-server",
     "vscode-html-language-server",

--- a/languages/templ/embedding_go.scm
+++ b/languages/templ/embedding_go.scm
@@ -1,3 +1,4 @@
+; From https://github.com/zed-industries/zed/blob/0f584cb353afe0483d8a044619b7dabcfcd10e40/crates/languages/src/go/embedding.scm
 (
     (comment)* @context
     .

--- a/languages/templ/highlights.scm
+++ b/languages/templ/highlights.scm
@@ -1,4 +1,3 @@
-; inherits: go
 (component_declaration
   name: (component_identifier) @function)
 
@@ -6,7 +5,9 @@
   (tag_start)
   (tag_end)
   (self_closing_tag)
-  (style_element)
+  (style_tag_start)
+  (style_tag_end)
+  (self_closing_style_tag)
 ] @tag
 
 (attribute
@@ -29,7 +30,6 @@
   value: (css_property_value) @string)
 
 [
-  (expression)
   (dynamic_class_attribute_value)
 ] @function.method
 

--- a/languages/templ/highlights_go.scm
+++ b/languages/templ/highlights_go.scm
@@ -1,3 +1,5 @@
+; From https://github.com/zed-industries/zed/blob/0f584cb353afe0483d8a044619b7dabcfcd10e40/crates/languages/src/go/highlights.scm
+
 (type_identifier) @type
 (field_identifier) @variable.member
 

--- a/languages/templ/indents.scm
+++ b/languages/templ/indents.scm
@@ -1,0 +1,8 @@
+; From https://github.com/zed-industries/zed/blob/49c53bc0ec85c38f579efbbcda9a1a84fb54e51f/extensions/html/languages/html/indents.scm
+ 
+(tag_start ">" @end) @indent
+(self_closing_tag "/>" @end) @indent
+
+(element
+  (tag_start) @start
+  (tag_end)? @end) @indent

--- a/languages/templ/indents_go.scm
+++ b/languages/templ/indents_go.scm
@@ -1,3 +1,5 @@
+; From https://github.com/zed-industries/zed/blob/0f584cb353afe0483d8a044619b7dabcfcd10e40/crates/languages/src/go/indents.scm
+
 [
     (assignment_statement)
     (call_expression)

--- a/languages/templ/injections.scm
+++ b/languages/templ/injections.scm
@@ -1,5 +1,3 @@
-; inherits: go
-
 ((script_block_text) @content
   (#set! "language" "JavaScript"))
 
@@ -8,3 +6,9 @@
 
 ((style_element_text) @content
   (#set! "language" "CSS"))
+
+((expression) @content
+  (#set! "language" "go"))
+
+((rawgo_block) @content
+  (#set! "language" "go"))

--- a/languages/templ/injections_go.scm
+++ b/languages/templ/injections_go.scm
@@ -1,0 +1,15 @@
+; From https://github.com/zed-industries/zed/blob/9d681bda8d607384703f14d9e6549165e5cb9ae4/crates/languages/src/go/injections.scm
+
+; Refer to https://github.com/nvim-treesitter/nvim-treesitter/blob/master/queries/go/injections.scm#L4C1-L16C41
+(call_expression
+  (selector_expression) @_function
+  (#any-of? @_function
+    "regexp.Match" "regexp.MatchReader" "regexp.MatchString" "regexp.Compile" "regexp.CompilePOSIX"
+    "regexp.MustCompile" "regexp.MustCompilePOSIX")
+  (argument_list
+    .
+    [
+      (raw_string_literal)
+      (interpreted_string_literal)
+    ] @content
+    (#set! "language" "regex")))

--- a/languages/templ/outline.scm
+++ b/languages/templ/outline.scm
@@ -1,5 +1,3 @@
-; inherits: go
-
 (component_declaration
     "templ" @context
     name: (component_identifier) @name
@@ -23,7 +21,12 @@
 ) @item
 
 (style_element
-    name: "style" @context
+    [
+        (style_tag_start 
+            "style" @context )
+        (self_closing_style_tag
+            "style" @context )
+    ]
 ) @item
 
 (script_element

--- a/languages/templ/outline_go.scm
+++ b/languages/templ/outline_go.scm
@@ -1,3 +1,6 @@
+; From https://github.com/zed-industries/zed/blob/2db2b636f24cce2066b722fd3167898e53b5296f/crates/languages/src/go/outline.scm
+
+(comment) @annotation
 (type_declaration
     "type" @context
     (type_spec
@@ -34,7 +37,7 @@
         (var_spec
             name: (identifier) @name) @item))
 
-(method_spec
+(method_elem
     name: (_) @name
     parameters: (parameter_list
       "(" @context

--- a/languages/templ/overrides_go.scm
+++ b/languages/templ/overrides_go.scm
@@ -1,8 +1,8 @@
-(comment) @comment
+; From https://github.com/zed-industries/zed/blob/258cf6c74684e662a52a3671b4550bad0c91e6d0/crates/languages/src/go/overrides.scm
+
+(comment) @comment.inclusive
 [
   (interpreted_string_literal)
   (raw_string_literal)
   (rune_literal)
-  (attribute_value)
-  (quoted_attribute_value)
 ] @string

--- a/languages/templ/textobjects.scm
+++ b/languages/templ/textobjects.scm
@@ -1,0 +1,25 @@
+(component_declaration
+    (component_block
+        "{"
+        (_)* @function.inside
+        "}")) @function.around
+
+(component_declaration
+    (component_block
+        "{"
+        (_)* @class.inside
+        "}")) @class.around
+
+; TODO: CSS blocks require the _css_block rule but it is marked private in templ/tree-sitter, not sure why.
+
+(script_declaration
+    (script_block
+        "{"
+        (_)* @class.inside
+        "}")) @class.around
+
+(script_declaration
+    (script_block
+        "{"
+        (_)* @function.inside
+        "}")) @function.around

--- a/languages/templ/textobjects_go.scm
+++ b/languages/templ/textobjects_go.scm
@@ -1,0 +1,27 @@
+; From https://github.com/zed-industries/zed/blob/75c9dc179bb3db89915666baf56e5362761cd97c/crates/languages/src/go/textobjects.scm
+
+(function_declaration
+    body: (_
+        "{"
+        (_)* @function.inside
+        "}")) @function.around
+
+(method_declaration
+    body: (_
+        "{"
+        (_)* @function.inside
+        "}")) @function.around
+
+(type_declaration
+    (type_spec (struct_type (field_declaration_list (
+        "{"
+        (_)* @class.inside
+        "}")?)))) @class.around
+
+(type_declaration
+    (type_spec (interface_type
+        (_)* @class.inside))) @class.around
+
+(type_declaration) @class.around
+
+(comment)+ @comment.around


### PR DESCRIPTION
**List of changes:**
- Add rawgo support
- Add vim mode support (except CSS blocks because the required query is marked private)
- Update tree-sitter-templ ref and update queries accordingly to account for grammar changes
- Update copied queries from the upstream official go/html extensions and separate them all into *_go.scm files
- Minor enhancements like treating templ expressions `{ ... }` as injected go

Closes https://github.com/makifdb/zed-templ/issues/8.

I've been running the extension with these changes on decently sized content for a few weeks now and haven't run into issues other than some I've found in tree-sitter-templ itself. This is my first update to an extension so let me know if any other changes are necessary.