### PR TITLE
fix tailwind autocomplete

### DIFF
--- a/languages/templ/overrides_go.scm
+++ b/languages/templ/overrides_go.scm
@@ -5,4 +5,6 @@
   (interpreted_string_literal)
   (raw_string_literal)
   (rune_literal)
+  (attribute_value)
+  (quoted_attribute_value)
 ] @string


### PR DESCRIPTION
This PR restores `attribute_value` and `quoted_attribute_value` to permit tailwind autocomplete to work.

- fixes #11