### PR TITLE
Fix Prettier plugin installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,15 +84,15 @@ Emmet is included in the configuration above. Use it by typing abbreviations and
 ### Prettier Formatting
 To use Prettier with Templ files:
 
-1. Install the Prettier plugin for Templ:
+1. Install the [Prettier plugin for Templ](https://github.com/therealparmesh/prettier-plugin-templ-script):
 ```bash
-npm install --save-dev prettier prettier-plugin-templ
+npm install --save-dev prettier prettier-plugin-templ-script
 ```
 
 2. Add to your `.prettierrc`:
 ```json
 {
-  "plugins": ["prettier-plugin-templ"],
+  "plugins": ["prettier-plugin-templ-script"],
   "overrides": [
     {
       "files": ["*.templ"],


### PR DESCRIPTION
This pull request updates the documentation to reference the correct Prettier plugin for Templ files. The instructions now point to the `prettier-plugin-templ-script` plugin instead of the previously referenced `prettier-plugin-templ`.

[`prettier-plugin-templ` does not exist.](https://www.npmjs.com/search?q=prettier-plugin-templ "https://www.npmjs.com/search?q=prettier-plugin-templ")

Documentation updates:

- Updated the Prettier setup instructions in `README.md` to use `prettier-plugin-templ-script` and provided a link to its repository.
- Updated the installation instructions for the Prettier plugin to use the correct package name.

Links:
- NPM: https://www.npmjs.com/package/prettier-plugin-templ-script
- GitHub: https://github.com/therealparmesh/prettier-plugin-templ-script
